### PR TITLE
Implement generic double ended queue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.22
 
       - name: Format
         run: go fmt ./...

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Requires Go 1.18+.
      * [NoSyncBroadcaster](https://pkg.go.dev/github.com/bitstonks/go-adt/broadcast#NoSyncBroadcaster) - subscribe, unsibscribe and send actions have to be synchronised externally
      * [SyncBroadcaster](https://pkg.go.dev/github.com/bitstonks/go-adt/broadcast#SyncBroadcaster) - actions are synchronised using an internal mutex
      * [ChanBroadcaster](https://pkg.go.dev/github.com/bitstonks/go-adt/broadcast#ChanBroadcaster) - actions are synchronised using channels and processed in an eventloop
+* `./deque`: [generic double ended queue](https://pkg.go.dev/github.com/bitstonks/go-adt/deque)

--- a/deque/deque.go
+++ b/deque/deque.go
@@ -1,0 +1,154 @@
+// deque provides a generic implementation of a double-ended queue.
+//
+// Using it as a queue is faster than using a slice, because it doesn't need to shift elements.
+// Below is a benchmark result showing 1.7x speedup when using deque instead of a slice.
+// ```
+// $ GOMAXPROCS=1 go test -benchmem -run=^$ -bench ^Benchmark.+_Queue$ ./deque -count=3
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/bitstonks/go-adt/deque
+// cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+// BenchmarkDeque_Queue    71107292                16.84 ns/op            0 B/op          0 allocs/op
+// BenchmarkDeque_Queue    70529484                17.62 ns/op            0 B/op          0 allocs/op
+// BenchmarkDeque_Queue    70236950                16.94 ns/op            0 B/op          0 allocs/op
+// BenchmarkSlice_Queue    40343143                29.30 ns/op           16 B/op          1 allocs/op
+// BenchmarkSlice_Queue    41047531                29.22 ns/op           16 B/op          1 allocs/op
+// BenchmarkSlice_Queue    40031304                28.95 ns/op           16 B/op          1 allocs/op
+// PASS
+// ok      github.com/bitstonks/go-adt/deque       7.508s
+// ```
+package deque
+
+type Deque[T any] struct {
+	data  []T
+	first uint
+	size  uint
+}
+
+// New creates a new deque.
+func New[T any](capacity uint) Deque[T] {
+	return Deque[T]{data: make([]T, capacity)}
+}
+
+// Len returns the number of elements in the deque.
+func (d *Deque[T]) Len() uint {
+	return d.size
+}
+
+// Cap returns the capacity of the deque.
+func (d *Deque[T]) Cap() uint {
+	return uint(len(d.data))
+}
+
+// PushBack adds an element to the back of the deque.
+func (d *Deque[T]) PushBack(elems ...T) {
+	n := uint(len(elems))
+	if d.Len()+n > d.Cap() {
+		d.ensureCapacity(n)
+	}
+	for i, elem := range elems {
+		d.data[(d.first+d.size+uint(i))%d.Cap()] = elem
+	}
+	d.size += n
+}
+
+// PushFront adds an element to the front of the deque.
+func (d *Deque[T]) PushFront(elems ...T) {
+	n := uint(len(elems))
+	if d.Len()+n > d.Cap() {
+		d.ensureCapacity(n)
+	}
+	c := d.Cap()
+	d.first = (d.first + c - n) % c
+	for i, elem := range elems {
+		d.data[(d.first+n-1-uint(i))%c] = elem
+	}
+	d.size += n
+}
+
+// PopBack removes and returns the element at the back of the deque.
+func (d *Deque[T]) PopBack() T {
+	if d.Len() == 0 {
+		panic("deque: PopBack() called on empty deque")
+	}
+	d.size--
+	idx := (d.first + d.size) % d.Cap()
+	elem := d.data[idx]
+	d.data[idx] = d.zeroElement()
+	return elem
+}
+
+// PopFront removes and returns the element at the front of the deque.
+func (d *Deque[T]) PopFront() T {
+	if d.Len() == 0 {
+		panic("deque: PopFront() called on empty deque")
+	}
+	elem := d.data[d.first]
+	d.data[d.first] = d.zeroElement()
+	d.first = (d.first + 1) % d.Cap()
+	d.size--
+	return elem
+}
+
+// Back returns the element at the back of the deque.
+func (d *Deque[T]) Back() T {
+	if d.Len() == 0 {
+		panic("deque: Back() called on empty deque")
+	}
+	return d.data[(d.first+d.size-1)%d.Cap()]
+}
+
+// Front returns the element at the front of the deque.
+func (d *Deque[T]) Front() T {
+	if d.Len() == 0 {
+		panic("deque: Front() called on empty deque")
+	}
+	return d.data[d.first]
+}
+
+// PopNBack removes and returns the last n elements from the deque.
+func (d *Deque[T]) PopNBack(n uint) []T {
+	if n > d.Len() {
+		panic("deque: PopNBack() called with n > Len()")
+	}
+	elems := make([]T, 0, n)
+	for i := d.first + d.size - 1; i >= d.first+d.size-n; i-- {
+		elems = append(elems, d.data[i%d.Cap()])
+		d.data[i%d.Cap()] = d.zeroElement()
+	}
+	d.size -= n
+	return elems
+}
+
+// PopNFront removes and returns the last n elements from the deque.
+func (d *Deque[T]) PopNFront(n uint) []T {
+	if n > d.Len() {
+		panic("deque: PopNFront() called with n > Len()")
+	}
+	c := d.Cap()
+	elems := make([]T, 0, n)
+	for i := d.first; i < d.first+n; i++ {
+		elems = append(elems, d.data[i%c])
+		d.data[i%c] = d.zeroElement()
+	}
+	d.first = (d.first + n) % c
+	d.size -= n
+	return elems
+}
+
+// checkCapacity will double the capacity of the deque until there is rome for n additional elements.
+func (d *Deque[T]) ensureCapacity(n uint) {
+	if d.Cap() == 0 {
+		d.data = make([]T, n)
+		return
+	}
+	for d.Len()+n > d.Cap() {
+		d.data = append(d.data, d.data...) // Double the capacity.
+	}
+	// Zero all elements before the first element and after the last element.
+	for i := d.first + d.size; i%d.Cap() != d.first; i++ {
+		d.data[i%d.Cap()] = d.zeroElement()
+	}
+}
+
+func (d *Deque[T]) zeroElement() (elem T) { return }

--- a/deque/deque.go
+++ b/deque/deque.go
@@ -1,21 +1,20 @@
 // deque provides a generic implementation of a double-ended queue.
 //
-// Using it as a queue is faster than using a slice, because it doesn't need to shift elements.
-// Below is a benchmark result showing 1.7x speedup when using deque instead of a slice.
+// Using it as a queue is faster than using a slice because it doesn't need to shift elements.
+// Below is a benchmark result showing over 3x speedup when using deque instead of a slice.
 // ```
-// $ GOMAXPROCS=1 go test -benchmem -run=^$ -bench ^Benchmark.+_Queue$ ./deque -count=3
-// goos: darwin
+// goos: linux
 // goarch: amd64
 // pkg: github.com/bitstonks/go-adt/deque
-// cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-// BenchmarkDeque_Queue    71107292                16.84 ns/op            0 B/op          0 allocs/op
-// BenchmarkDeque_Queue    70529484                17.62 ns/op            0 B/op          0 allocs/op
-// BenchmarkDeque_Queue    70236950                16.94 ns/op            0 B/op          0 allocs/op
-// BenchmarkSlice_Queue    40343143                29.30 ns/op           16 B/op          1 allocs/op
-// BenchmarkSlice_Queue    41047531                29.22 ns/op           16 B/op          1 allocs/op
-// BenchmarkSlice_Queue    40031304                28.95 ns/op           16 B/op          1 allocs/op
+// cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+// BenchmarkDeque_Queue    127719072                9.260 ns/op           0 B/op          0 allocs/op
+// BenchmarkDeque_Queue    128505860                9.423 ns/op           0 B/op          0 allocs/op
+// BenchmarkDeque_Queue    127933101                9.170 ns/op           0 B/op          0 allocs/op
+// BenchmarkSlice_Queue    32121012                32.11 ns/op           16 B/op          1 allocs/op
+// BenchmarkSlice_Queue    33130184                32.16 ns/op           16 B/op          1 allocs/op
+// BenchmarkSlice_Queue    37404979                32.28 ns/op           16 B/op          1 allocs/op
 // PASS
-// ok      github.com/bitstonks/go-adt/deque       7.508s
+// ok      github.com/bitstonks/go-adt/deque       10.442s
 // ```
 package deque
 

--- a/deque/deque_benchmark_test.go
+++ b/deque/deque_benchmark_test.go
@@ -1,0 +1,52 @@
+package deque
+
+import (
+	"testing"
+)
+
+var sink int
+
+func BenchmarkDeque_PushBack(b *testing.B) {
+	var d Deque[int]
+	for i := range b.N {
+		d.PushBack(i)
+	}
+}
+func BenchmarkDeque_PushFront(b *testing.B) {
+	var d Deque[int]
+	for i := range b.N {
+		d.PushFront(i)
+	}
+}
+func BenchmarkDeque_PopBack(b *testing.B) {
+	d := Deque[int]{data: make([]int, b.N), size: uint(b.N), first: 0}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink = d.PopBack()
+	}
+}
+func BenchmarkDeque_PopFront(b *testing.B) {
+	d := Deque[int]{data: make([]int, b.N), size: uint(b.N), first: 0}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink = d.PopFront()
+	}
+}
+func BenchmarkDeque_Queue(b *testing.B) {
+	q := New[int](2)
+	q.PushBack(0, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink = q.PopFront()
+		q.PushBack(0)
+	}
+}
+func BenchmarkSlice_Queue(b *testing.B) {
+	q := make([]int, 2)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink = q[0]
+		q = q[1:]
+		q = append(q, 0)
+	}
+}

--- a/deque/deque_test.go
+++ b/deque/deque_test.go
@@ -1,0 +1,167 @@
+package deque
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleDeque_stack() {
+	var stack Deque[int]
+	stack.PushBack(1, 2)
+	fmt.Println(stack.PopBack())
+	stack.PushBack(3, 4, 5)
+	fmt.Println(stack.PopBack())
+	fmt.Println(stack.Back())
+	fmt.Println(stack.PopNBack(2))
+	fmt.Println(stack.PopBack())
+
+	// Output:
+	// 2
+	// 5
+	// 4
+	// [4 3]
+	// 1
+}
+
+func ExampleDeque_queue() {
+	var queue Deque[int]
+	queue.PushBack(1, 2)
+	fmt.Println(queue.PopFront())
+	queue.PushBack(3, 4, 5)
+	fmt.Println(queue.PopFront())
+	fmt.Println(queue.Front())
+	fmt.Println(queue.PopNFront(2))
+	fmt.Println(queue.PopFront())
+
+	// Output:
+	// 1
+	// 2
+	// 3
+	// [3 4]
+	// 5
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	d := New[int](4)
+	assert.NotNil(t, d)
+	assert.Zero(t, d.Len())
+	assert.EqualValues(t, 4, d.Cap())
+}
+
+func TestDeque_PushBack(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: make([]int, 2), first: 1, size: 0}
+	d.PushBack(1)
+	assert.EqualValues(t, []int{0, 1}, d.data)
+	d.PushBack(2, 3)
+	assert.EqualValues(t, []int{0, 1, 2, 3}, d.data)
+}
+
+func TestDeque_PushFront(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: make([]int, 2), first: 1, size: 0}
+	d.PushFront(1)
+	assert.EqualValues(t, []int{1, 0}, d.data)
+	d.PushFront(2, 3)
+	assert.EqualValues(t, []int{1, 0, 3, 2}, d.data)
+}
+
+func TestDeque_PopBack(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: []int{1, 2, 3, 4}, first: 2, size: 4}
+	assert.Equal(t, 2, d.PopBack())
+	assert.Equal(t, 1, d.PopBack())
+	assert.Equal(t, 4, d.PopBack())
+	assert.Equal(t, 3, d.PopBack())
+	assert.PanicsWithValue(t, "deque: PopBack() called on empty deque", func() { d.PopBack() })
+}
+func TestDeque_PopFront(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: []int{1, 2, 3, 4}, first: 2, size: 4}
+	assert.Equal(t, 3, d.PopFront())
+	assert.Equal(t, 4, d.PopFront())
+	assert.Equal(t, 1, d.PopFront())
+	assert.Equal(t, 2, d.PopFront())
+	assert.PanicsWithValue(t, "deque: PopFront() called on empty deque", func() { d.PopFront() })
+}
+
+func TestDeque_Back(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: []int{1, 2, 3, 4}, first: 2, size: 4}
+	assert.Equal(t, 2, d.Back())
+	d.PopBack()
+	assert.Equal(t, 1, d.Back())
+	d.PopNBack(3)
+	assert.PanicsWithValue(t, "deque: Back() called on empty deque", func() { d.Back() })
+}
+func TestDeque_Front(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: []int{1, 2, 3, 4}, first: 2, size: 4}
+	assert.Equal(t, 3, d.Front())
+	d.PopFront()
+	assert.Equal(t, 4, d.Front())
+	d.PopNFront(3)
+	assert.PanicsWithValue(t, "deque: Front() called on empty deque", func() { d.Front() })
+}
+func TestDeque_PopNBack(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: []int{1, 2, 3, 4}, first: 2, size: 4}
+	assert.EqualValues(t, []int{2, 1}, d.PopNBack(2))
+	assert.EqualValues(t, []int{0, 0, 3, 4}, d.data)
+	assert.Equal(t, 4, d.Back())
+	assert.PanicsWithValue(t, "deque: PopNBack() called with n > Len()", func() { d.PopNBack(3) })
+}
+func TestDeque_PopNFront(t *testing.T) {
+	t.Parallel()
+	d := Deque[int]{data: []int{1, 2, 3, 4}, first: 2, size: 4}
+	assert.EqualValues(t, []int{3, 4}, d.PopNFront(2))
+	assert.EqualValues(t, []int{1, 2, 0, 0}, d.data)
+	assert.Equal(t, 1, d.Front())
+	assert.PanicsWithValue(t, "deque: PopNFront() called with n > Len()", func() { d.PopNFront(3) })
+}
+
+func TestEnsureCapacity(t *testing.T) {
+	t.Parallel()
+	for _, capacity := range []uint{0, 1, 17} {
+		capacity := capacity
+		t.Run(fmt.Sprintf("from empty to %d", capacity), func(t *testing.T) {
+			t.Parallel()
+			var d Deque[int]
+			d.ensureCapacity(capacity)
+			assert.EqualValues(t, capacity, len(d.data))
+			assert.Equal(t, capacity, d.Cap())
+			assert.Zero(t, d.first)
+			assert.Zero(t, d.size)
+			for i := range capacity {
+				assert.Zero(t, d.data[i])
+			}
+		})
+	}
+	t.Run("from one to 2", func(t *testing.T) {
+		t.Parallel()
+		d := Deque[int]{data: []int{1}, first: 0, size: 1}
+		d.ensureCapacity(1)
+		assert.EqualValues(t, []int{1, 0}, d.data)
+	})
+	t.Run("from one to 6", func(t *testing.T) {
+		t.Parallel()
+		d := Deque[int]{data: []int{1}, first: 0, size: 1}
+		d.ensureCapacity(5)
+		assert.EqualValues(t, []int{1, 0, 0, 0, 0, 0, 0, 0}, d.data)
+	})
+	t.Run("noop", func(t *testing.T) {
+		t.Parallel()
+		d := Deque[int]{data: []int{1, 2, 3, 0}, first: 0, size: 3}
+		d.ensureCapacity(1)
+		assert.EqualValues(t, []int{1, 2, 3, 0}, d.data)
+	})
+	t.Run("crossed", func(t *testing.T) {
+		t.Parallel()
+		d := Deque[int]{data: []int{3, 4, 1, 2}, first: 2, size: 4}
+		d.ensureCapacity(1)
+		assert.EqualValues(t, []int{0, 0, 1, 2, 3, 4, 0, 0}, d.data)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/bitstonks/go-adt
 
 go 1.22
 
-require github.com/stretchr/testify v1.7.1
+require github.com/stretchr/testify v1.9.0
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,8 @@
 module github.com/bitstonks/go-adt
 
-go 1.18
+go 1.22
 
-require (
-	github.com/stretchr/testify v1.7.1
-	golang.org/x/exp v0.0.0-20220317015231-48e79f11773a
-)
+require github.com/stretchr/testify v1.7.1
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,17 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/exp v0.0.0-20220317015231-48e79f11773a h1:DAzrdbxsb5tXNOhMCSwF7ZdfMbW46hE9fSVO6BsmUZM=
-golang.org/x/exp v0.0.0-20220317015231-48e79f11773a/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
Having a deque to use as a queue can be significantly faster than using a slice that you continually re-allocate.
Below is a benchmark result showing 1.7x speedup when using deque instead of a slice. See deque_benchmark_test.go for exact test that was run.
```
$ GOMAXPROCS=1 go test -benchmem -run=^$ -bench ^Benchmark.+_Queue$ ./deque -count=3
goos: darwin
goarch: amd64
pkg: github.com/bitstonks/go-adt/deque
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDeque_Queue    71107292                16.84 ns/op            0 B/op          0 allocs/op
BenchmarkDeque_Queue    70529484                17.62 ns/op            0 B/op          0 allocs/op
BenchmarkDeque_Queue    70236950                16.94 ns/op            0 B/op          0 allocs/op
BenchmarkSlice_Queue    40343143                29.30 ns/op           16 B/op          1 allocs/op
BenchmarkSlice_Queue    41047531                29.22 ns/op           16 B/op          1 allocs/op
BenchmarkSlice_Queue    40031304                28.95 ns/op           16 B/op          1 allocs/op
PASS
ok      github.com/bitstonks/go-adt/deque       7.508s
```