### PR TITLE
Create a type safe wrapper around sync.Map

### DIFF
--- a/sync_map/map.go
+++ b/sync_map/map.go
@@ -1,0 +1,86 @@
+// sync_map includes a thin wrapper around sync.Map
+// which adds type safety to it.
+package sync_map
+
+import "sync"
+
+// Map is a type safe thin wrapper around sync.Map.
+type Map[K, V any] struct {
+	m sync.Map
+}
+
+// CompareAndDelete deletes the entry for key if its value is equal to old.
+// The old value must be of a comparable type.
+//
+// If there is no current value for key in the map, CompareAndDelete
+// returns false (even if the old value is zero value).
+func (m *Map[K, V]) CompareAndDelete(key K, old V) (deleted bool) {
+	return m.m.CompareAndDelete(key, old)
+}
+
+// CompareAndSwap swaps the old and new values for key
+// if the value stored in the map is equal to old.
+// The old value must be of a comparable type.
+func (m *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
+	return m.m.CompareAndSwap(key, old, new)
+}
+
+// Delete deletes the value for a key.
+func (m *Map[K, V]) Delete(key K) {
+	m.m.Delete(key)
+}
+
+// Load returns the value stored in the map for a key, or V zero
+// value if no value is present.
+// The ok result indicates whether value was found in the map.
+func (m *Map[K, V]) Load(key K) (value V, ok bool) {
+	val, ok := m.m.Load(key)
+	value, _ = val.(V)
+	return
+
+}
+
+// LoadAndDelete deletes the value for a key, returning the previous value if any.
+// The loaded result reports whether the key was present.
+func (m *Map[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
+	v, loaded := m.m.LoadAndDelete(key)
+	value, _ = v.(V)
+	return
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	a, loaded := m.m.LoadOrStore(key, value)
+	actual = a.(V)
+	return
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+//
+// Range does not necessarily correspond to any consistent snapshot of the Map's
+// contents: no key will be visited more than once, but if the value for any key
+// is stored or deleted concurrently (including by f), Range may reflect any
+// mapping for that key from any point during the Range call. Range does not
+// block other methods on the receiver; even f itself may call any method on m.
+//
+// Range may be O(N) with the number of elements in the map even if f returns
+// false after a constant number of calls.
+func (m *Map[K, V]) Range(f func(key K, value V) bool) {
+	m.m.Range(func(key, value any) bool { return f(key.(K), value.(V)) })
+}
+
+// Store sets the value for a key.
+func (m *Map[K, V]) Store(key K, value V) {
+	m.m.Store(key, value)
+}
+
+// Swap swaps the value for a key and returns the previous value if any.
+// The loaded result reports whether the key was present.
+func (m *Map[K, V]) Swap(key K, value V) (previous V, loaded bool) {
+	p, loaded := m.m.Swap(key, value)
+	previous, _ = p.(V)
+	return
+}

--- a/sync_map/map_test.go
+++ b/sync_map/map_test.go
@@ -1,0 +1,140 @@
+package sync_map_test
+
+import (
+	"testing"
+
+	"github.com/bitstonks/go-adt/sync_map"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMap_Basic(t *testing.T) {
+	t.Parallel()
+	var m sync_map.Map[int, string]
+	t.Run("load from empty", func(t *testing.T) {
+		v, ok := m.Load(1)
+		assert.Equal(t, "", v)
+		assert.Equal(t, false, ok)
+	})
+	t.Run("store&load", func(t *testing.T) {
+		m.Store(1, "Hello")
+		v, ok := m.Load(1)
+		assert.Equal(t, "Hello", v)
+		assert.Equal(t, true, ok)
+	})
+	t.Run("delete", func(t *testing.T) {
+		m.Delete(1)
+		v, ok := m.Load(1)
+		assert.Equal(t, "", v)
+		assert.Equal(t, false, ok)
+	})
+}
+
+func TestCompareAndDelete(t *testing.T) {
+	t.Parallel()
+	var m sync_map.Map[int, string]
+
+	assert.False(t, m.CompareAndDelete(1, "Hello"))
+
+	m.Store(1, "Hello")
+	assert.True(t, m.CompareAndDelete(1, "Hello"))
+	v, ok := m.Load(1)
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+
+	m.Store(1, "World")
+	assert.False(t, m.CompareAndDelete(1, "Hello"))
+	v, ok = m.Load(1)
+	assert.True(t, ok)
+	assert.Equal(t, "World", v)
+}
+
+func TestCompareAndSwap(t *testing.T) {
+	t.Parallel()
+	var m sync_map.Map[int, string]
+
+	assert.False(t, m.CompareAndSwap(1, "Hello", "World"))
+
+	m.Store(1, "Hello")
+	assert.True(t, m.CompareAndSwap(1, "Hello", "World"))
+	v, ok := m.Load(1)
+	assert.True(t, ok)
+	assert.Equal(t, "World", v)
+
+	assert.False(t, m.CompareAndSwap(1, "Hello", "Earth"))
+	v, ok = m.Load(1)
+	assert.True(t, ok)
+	assert.Equal(t, "World", v)
+}
+
+func TestLoadAndDelete(t *testing.T) {
+	t.Parallel()
+	var m sync_map.Map[int, string]
+
+	v, ok := m.LoadAndDelete(1)
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+
+	m.Store(1, "Hello")
+	v, ok = m.LoadAndDelete(1)
+	assert.True(t, ok)
+	assert.Equal(t, "Hello", v)
+
+	v, ok = m.Load(1)
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+}
+
+func TestMap_LoadOrStore(t *testing.T) {
+	t.Parallel()
+	var m sync_map.Map[int, string]
+
+	actual, loaded := m.LoadOrStore(1, "Hello")
+	assert.Equal(t, "Hello", actual)
+	assert.False(t, loaded)
+
+	actual, loaded = m.LoadOrStore(1, "World")
+	assert.Equal(t, "Hello", actual)
+	assert.True(t, loaded)
+
+	v, ok := m.Load(1)
+	assert.True(t, ok)
+	assert.Equal(t, "Hello", v)
+
+	actual, loaded = m.LoadOrStore(2, "Goodbye")
+	assert.Equal(t, "Goodbye", actual)
+	assert.False(t, loaded)
+
+	v, ok = m.Load(2)
+	assert.True(t, ok)
+	assert.Equal(t, "Goodbye", v)
+}
+
+func TestRange(t *testing.T) {
+	t.Parallel()
+	var m sync_map.Map[int, string]
+	m.Store(1, "Hello")
+	m.Store(2, "World")
+	m.Store(30, "Goodbye")
+	got := make(map[int]string)
+	m.Range(func(k int, v string) bool {
+		got[k] = v
+		return true
+	})
+	assert.Equal(t, map[int]string{1: "Hello", 2: "World", 30: "Goodbye"}, got)
+}
+
+func TestSwap(t *testing.T) {
+	t.Parallel()
+	var m sync_map.Map[int, string]
+	v, ok := m.Swap(1, "Hello")
+	assert.Equal(t, "", v)
+	assert.False(t, ok)
+
+	v, ok = m.Load(1)
+	assert.Equal(t, "Hello", v)
+	assert.True(t, ok)
+
+	v, ok = m.Swap(1, "World")
+	assert.Equal(t, "Hello", v)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
sync.Map is useful sometimes, but usually not worth losing type safety for it. This wrapper helps fight that downside.